### PR TITLE
Add RSS feed for blog entries

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -75,6 +75,8 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build ContentLayer
         run: ${{ steps.detect-package-manager.outputs.runner }} contentlayer build
+      - name: Generate RSS Feed
+        run: node scripts/generate-rss.mjs
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Static HTML export with Next.js

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ next-env.d.ts
 
 # Contentlayer
 .contentlayer
+
+# Generated RSS feed
+/public/feed.xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-type-animation": "^3.2.0",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.0",
+        "rss": "^1.2.2",
         "swiper": "^9.3.2",
         "tailwindcss": "3.3.2",
         "typescript": "5.0.4"
@@ -10469,6 +10470,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.25.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -13490,6 +13512,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
@@ -14624,6 +14656,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -21016,6 +21054,19 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w=="
+    },
+    "mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==",
+      "requires": {
+        "mime-db": "~1.25.0"
+      }
+    },
     "mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -22814,6 +22865,15 @@
         "glob": "^7.1.3"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      }
+    },
     "run-applescript": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
@@ -23588,6 +23648,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "contentlayer build && next dev",
-    "build": "contentlayer build && next build",
+    "dev": "contentlayer build && node scripts/generate-rss.mjs && next dev",
+    "build": "contentlayer build && node scripts/generate-rss.mjs && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-type-animation": "^3.2.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0",
+    "rss": "^1.2.2",
     "swiper": "^9.3.2",
     "tailwindcss": "3.3.2",
     "typescript": "5.0.4"

--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -1,105 +1,34 @@
-import { readdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+import RSS from "rss";
 
 const SITE_URL = "https://intelowlproject.github.io";
-const BLOG_DIR = "Blogs";
+const POSTS_JSON = ".contentlayer/generated/Post/_index.json";
 const OUTPUT_PATH = "public/feed.xml";
 
-function parseFrontmatter(content) {
-  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-  if (!match) return null;
-
-  const meta = {};
-  for (const line of match[1].split("\n")) {
-    const idx = line.indexOf(":");
-    if (idx === -1) continue;
-    const key = line.slice(0, idx).trim();
-    const value = line.slice(idx + 1).trim();
-    meta[key] = value;
-  }
-  return { meta, body: match[2] };
-}
-
-function stripMarkdown(text) {
-  return text
-    .replace(/!\[.*?\]\(.*?\)/g, "") // images
-    .replace(/\[([^\]]*)\]\(.*?\)/g, "$1") // links -> text
-    .replace(/#{1,6}\s+/g, "") // headings
-    .replace(/[*_~`>]/g, "") // emphasis, code, blockquote markers
-    .replace(/\n{2,}/g, " ") // collapse newlines
-    .replace(/\s+/g, " ") // collapse whitespace
-    .trim();
-}
-
-function escapeXml(str) {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
-}
-
-function slugFromFilename(filename) {
-  return filename.replace(/\.md$/, "");
-}
-
 async function main() {
-  const files = (await readdir(BLOG_DIR)).filter((f) => f.endsWith(".md"));
+  const posts = JSON.parse(await readFile(POSTS_JSON, "utf-8"));
+  posts.sort((a, b) => new Date(b.date) - new Date(a.date));
 
-  const posts = [];
-  for (const file of files) {
-    const raw = await readFile(join(BLOG_DIR, file), "utf-8");
-    const parsed = parseFrontmatter(raw);
-    if (!parsed) continue;
+  const feed = new RSS({
+    title: "IntelOwl Project Blog",
+    description: "Latest updates from the IntelOwl Project",
+    feed_url: `${SITE_URL}/feed.xml`,
+    site_url: `${SITE_URL}/blogs`,
+    language: "en",
+  });
 
-    const { meta, body } = parsed;
-    const slug = slugFromFilename(file);
-    const plainBody = stripMarkdown(body);
-    const description =
-      plainBody.length > 250 ? plainBody.slice(0, 250) + "..." : plainBody;
-
-    posts.push({
-      title: meta.title || slug,
-      date: meta.date || "1970-01-01",
-      author: meta.author || "IntelOwl Project",
-      slug,
-      description,
+  for (const post of posts) {
+    const plain = post.body.html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+    feed.item({
+      title: post.title,
+      description: plain.length > 250 ? plain.slice(0, 250) + "..." : plain,
+      url: `${SITE_URL}${post.url}`,
+      author: post.author || "IntelOwl Project",
+      date: new Date(post.date),
     });
   }
 
-  posts.sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0));
-
-  const now = new Date().toUTCString();
-
-  const items = posts
-    .map(
-      (p) => `    <item>
-      <title>${escapeXml(p.title)}</title>
-      <link>${SITE_URL}/blogs/${p.slug}</link>
-      <guid>${SITE_URL}/blogs/${p.slug}</guid>
-      <pubDate>${new Date(p.date).toUTCString()}</pubDate>
-      <dc:creator>${escapeXml(p.author)}</dc:creator>
-      <description>${escapeXml(p.description)}</description>
-    </item>`,
-    )
-    .join("\n");
-
-  const rss = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <channel>
-    <title>IntelOwl Project Blog</title>
-    <link>${SITE_URL}/blogs</link>
-    <description>Latest updates from the IntelOwl Project</description>
-    <language>en</language>
-    <lastBuildDate>${now}</lastBuildDate>
-    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
-${items}
-  </channel>
-</rss>
-`;
-
-  await writeFile(OUTPUT_PATH, rss, "utf-8");
+  await writeFile(OUTPUT_PATH, feed.xml({ indent: true }), "utf-8");
   console.log(`RSS feed generated: ${OUTPUT_PATH} (${posts.length} posts)`);
 }
 

--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -18,10 +18,9 @@ async function main() {
   });
 
   for (const post of posts) {
-    const plain = post.body.html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
     feed.item({
       title: post.title,
-      description: plain.length > 250 ? plain.slice(0, 250) + "..." : plain,
+      description: post.body.html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim(),
       url: `${SITE_URL}${post.url}`,
       author: post.author || "IntelOwl Project",
       date: new Date(post.date),

--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -1,0 +1,109 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const SITE_URL = "https://intelowlproject.github.io";
+const BLOG_DIR = "Blogs";
+const OUTPUT_PATH = "public/feed.xml";
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+
+  const meta = {};
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    meta[key] = value;
+  }
+  return { meta, body: match[2] };
+}
+
+function stripMarkdown(text) {
+  return text
+    .replace(/!\[.*?\]\(.*?\)/g, "") // images
+    .replace(/\[([^\]]*)\]\(.*?\)/g, "$1") // links -> text
+    .replace(/#{1,6}\s+/g, "") // headings
+    .replace(/[*_~`>]/g, "") // emphasis, code, blockquote markers
+    .replace(/\n{2,}/g, " ") // collapse newlines
+    .replace(/\s+/g, " ") // collapse whitespace
+    .trim();
+}
+
+function escapeXml(str) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function slugFromFilename(filename) {
+  return filename.replace(/\.md$/, "");
+}
+
+async function main() {
+  const files = (await readdir(BLOG_DIR)).filter((f) => f.endsWith(".md"));
+
+  const posts = [];
+  for (const file of files) {
+    const raw = await readFile(join(BLOG_DIR, file), "utf-8");
+    const parsed = parseFrontmatter(raw);
+    if (!parsed) continue;
+
+    const { meta, body } = parsed;
+    const slug = slugFromFilename(file);
+    const plainBody = stripMarkdown(body);
+    const description =
+      plainBody.length > 250 ? plainBody.slice(0, 250) + "..." : plainBody;
+
+    posts.push({
+      title: meta.title || slug,
+      date: meta.date || "1970-01-01",
+      author: meta.author || "IntelOwl Project",
+      slug,
+      description,
+    });
+  }
+
+  posts.sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0));
+
+  const now = new Date().toUTCString();
+
+  const items = posts
+    .map(
+      (p) => `    <item>
+      <title>${escapeXml(p.title)}</title>
+      <link>${SITE_URL}/blogs/${p.slug}</link>
+      <guid>${SITE_URL}/blogs/${p.slug}</guid>
+      <pubDate>${new Date(p.date).toUTCString()}</pubDate>
+      <dc:creator>${escapeXml(p.author)}</dc:creator>
+      <description>${escapeXml(p.description)}</description>
+    </item>`,
+    )
+    .join("\n");
+
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>IntelOwl Project Blog</title>
+    <link>${SITE_URL}/blogs</link>
+    <description>Latest updates from the IntelOwl Project</description>
+    <language>en</language>
+    <lastBuildDate>${now}</lastBuildDate>
+    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>
+`;
+
+  await writeFile(OUTPUT_PATH, rss, "utf-8");
+  console.log(`RSS feed generated: ${OUTPUT_PATH} (${posts.length} posts)`);
+}
+
+main().catch((err) => {
+  console.error("Failed to generate RSS feed:", err);
+  process.exit(1);
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,11 @@ export const metadata = {
   icons: {
     icon: 'images/favicon.png',
   },
+  alternates: {
+    types: {
+      'application/rss+xml': '/feed.xml',
+    },
+  },
 }
 
 export default function RootLayout({


### PR DESCRIPTION
A RSS feed would be useful to dynamically display GreedyBear related blog posts on its start page, see https://github.com/intelowlproject/GreedyBear/pull/777 .

Disclaimer: I vibe coded this with claude code, because I don't know next.js and this feature is non-critical. It's basically a simple script that lists blog posts and builds a XML file out of them. I tested the generation locally and it works. Also I used the [W3C validation service](https://validator.w3.org/feed/) to check if the output is actually a valid RSS feed.  Here is Claudes implementation plan:

# Plan: Add RSS Feed to IntelOwlWeb

## Context

The IntelOwlWeb site has a blog section with markdown posts but no RSS feed. We'll add a build-time RSS feed generator so readers can subscribe to blog updates. The site is statically exported to GitHub Pages.

## Approach

Create a standalone Node.js script that parses the markdown blog posts, generates RSS 2.0 XML, and writes it to `public/feed.xml`. No new npm dependencies — the frontmatter is simple key-value YAML that can be parsed with a few lines of code, and RSS XML is straightforward to template.

## Files to create/modify

### 1. Create `scripts/generate-rss.mjs`

A Node.js script that:
- Reads all `.md` files from `Blogs/`
- Parses frontmatter (title, date, author) with simple string splitting
- Extracts the first ~250 chars of body text as description (strip markdown)
- Sorts posts by date descending
- Generates RSS 2.0 XML with proper escaping
- Writes to `public/feed.xml`

Site URL will be set as a constant at the top (defaulting to `https://intelowlproject.github.io`; easy to update if a custom domain is added).

### 2. Modify `package.json`

Update the `build` and `dev` scripts to run RSS generation after ContentLayer build:
```
"dev": "contentlayer build && node scripts/generate-rss.mjs && next dev"
"build": "contentlayer build && node scripts/generate-rss.mjs && next build"
```

### 3. Modify `src/app/layout.tsx`

Add an RSS `<link>` alternate to the metadata so browsers/readers can discover the feed:
```tsx
alternates: {
  types: {
    'application/rss+xml': '/feed.xml',
  },
},
```

### 4. Modify `.github/workflows/nextjs.yml`

Add a "Generate RSS Feed" step after "Build ContentLayer" and before "Build with Next.js":
```yaml
- name: Generate RSS Feed
  run: node scripts/generate-rss.mjs
```

### 5. Modify `.gitignore`

Add `/public/feed.xml` since it's a generated build artifact.

## Verification

1. Run `node scripts/generate-rss.mjs` and confirm `public/feed.xml` is created with valid RSS XML containing all blog posts
2. Run `npm run build` and confirm `out/feed.xml` exists in the static export
3. Run `npm run dev` and visit `/feed.xml` to verify the feed is served
