### PR TITLE
fix: remove trailing slash from installation URLs to prevent redirect

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -49,7 +49,7 @@ export default function HeroSection(props: HeroSectionProps) {
               <span className="text-[#00ADEF]">single API request.</span>
             </h2>
             <Link
-              href="https://intelowlproject.github.io/docs/IntelOwl/installation/"
+              href="https://intelowlproject.github.io/docs/IntelOwl/installation"
               className=" transform transition-transform duration-3 hover:scale-110 btn bg-[#00ADEE] hover:bg-blue-700 text-white py-2 mb-12 px-4 text-sm rounded w-32 h-10 mt-8 font-SpaceGrotesk text-center"
             >
               get started ➔
@@ -97,7 +97,7 @@ export default function HeroSection(props: HeroSectionProps) {
               </span>
             </h2>
             <Link
-              href="https://intelowlproject.github.io/docs/IntelOwl/installation/"
+              href="https://intelowlproject.github.io/docs/IntelOwl/installation"
               className="transform transition-transform duration-3 hover:scale-110 btn bg-[#00ADEE] hover:bg-blue-700 text-white py-2 px-4 rounded w-36 h-10 mt-16 font-SpaceGrotesk text-center"
             >
               get started ➔

--- a/constants/faqdata.ts
+++ b/constants/faqdata.ts
@@ -2,7 +2,7 @@ export const FAQData = [
   {
     question: "How can I install IntelOwl?",
     answer:
-      'That is super fast and straightforward: follow the guide <a href="https://intelowlproject.github.io/docs/IntelOwl/installation/" target="_blank">here</a>',
+      'That is super fast and straightforward: follow the guide <a href="https://intelowlproject.github.io/docs/IntelOwl/installation" target="_blank">here</a>',
   },
   {
     question:


### PR DESCRIPTION
### Description
This PR removes trailing slash from installation URLs to prevent redirect.

### Fixes : #59 